### PR TITLE
Update SimpleSSDB.php

### DIFF
--- a/app/classes/SimpleSSDB.php
+++ b/app/classes/SimpleSSDB.php
@@ -20,7 +20,7 @@ class SimpleSSDB extends SSDB
 {
 	function __construct($host, $port, $timeout_ms=2000){
 		parent::__construct($host, $port, $timeout_ms);
-		$this->easy();
+		self::easy();
 	}
 }
 


### PR DESCRIPTION
修复 nginx+php5.5 中出现`Cannot redeclare class SimpleSSDB`的问题
